### PR TITLE
refactor: 학생 정보 페이지 성능 최적화 작업

### DIFF
--- a/ico/src/components/common/Button/Button.tsx
+++ b/ico/src/components/common/Button/Button.tsx
@@ -198,7 +198,7 @@ const buttonCSS = ({ theme }: { theme: string }) => {
 			border: none;
 			border-radius: 20px;
 			background-color: var(--teacher-gray2-color);
-			color: var(--teacher-gray-color);
+			color: var(--teacher-gray3-color);
 		`,
 	}
 

--- a/ico/src/components/teacher/Class/Student/Detail/ClassStudentDetailHead.tsx
+++ b/ico/src/components/teacher/Class/Student/Detail/ClassStudentDetailHead.tsx
@@ -81,18 +81,26 @@ function ClassStudentDetailHead({ student }: ClassStudentDetailHeadPropsType) {
 						e.stopPropagation()
 					}}
 					onChange={changeToggleState}
+					id={`${student.id}`}
 				/>
-				<h5 css={numberCSS}>{student.number}</h5>
-				<h5 css={nameCSS}>{student.name}</h5>
-				<h5 css={jobCSS}>{student.job ? student.job : "무직"}</h5>
+				<label
+					htmlFor={`${student.id}`}
+					onClick={(e) => {
+						e.stopPropagation()
+					}}
+				>
+					<span css={numberCSS}>{student.number}</span>
+					<span css={nameCSS}>{student.name}</span>
+				</label>
+				<span css={jobCSS}>{student.job ? student.job : "무직"}</span>
 			</div>
 			<div css={rightWrapperCSS}>
-				<h5 css={amountCSS}>
+				<span css={amountCSS}>
 					{student.amount} {nation.currency}
-				</h5>
+				</span>
 				<ClassStudentDetailMoney studentId={student.id} manageAll={false} />
 				<div css={divideCSS}></div>
-				<h5 css={creditRatingCSS}>{student.creditRating}등급</h5>
+				<span css={creditRatingCSS}>{student.creditRating}등급</span>
 				<div css={buttonWrapperCSS}>
 					<div
 						onClick={(e) => {
@@ -147,7 +155,7 @@ const leftWrapperCSS = css`
 	align-items: center;
 	gap: 15px;
 
-	> h5 {
+	> span {
 		font-size: var(--teacher-h5);
 	}
 
@@ -165,6 +173,12 @@ const leftWrapperCSS = css`
 			border: none;
 		}
 	}
+
+	> label {
+		display: flex;
+		flex-direction: row;
+		min-width: 100px;
+	}
 `
 
 const rightWrapperCSS = css`
@@ -175,12 +189,11 @@ const rightWrapperCSS = css`
 `
 
 const numberCSS = css`
-	min-width: 20px;
+	min-width: 25px;
 `
 
 const nameCSS = css`
 	font-weight: bold;
-	min-width: 55px;
 `
 
 const jobCSS = css`

--- a/ico/src/components/teacher/layout/SideBar/SideBar.tsx
+++ b/ico/src/components/teacher/layout/SideBar/SideBar.tsx
@@ -42,7 +42,7 @@ function SideBar({ children }: SideBarProps) {
 	useEffect(() => {
 		// Object.keys(SUB_ELEMENT).forEach((el: string, idx: number) => {
 		// 	if (SUB_ELEMENT[Number(el)][router.pathname]) {
-				
+
 		// 		setSelectedMain(() => Number(el))
 		// 		const curRoute = SUB_ELEMENT[Number(el)][router.pathname]
 
@@ -53,23 +53,20 @@ function SideBar({ children }: SideBarProps) {
 		// 			const temp = curRoute.for
 		// 			setSelectedSub(() => temp)
 		// 		}
-				
+
 		// 	} else {
 
 		// 		if (Object.keys(SUB_ELEMENT).length - 1 === idx && selectedMain == -1 && selectedSub == -1) {
-					
+
 		// 			setSelectedMain(() => -2)
 		// 			setSelectedSub(() => -2)
 		// 		}
 		// 	}
-			
-				
-			
+
 		// })
 
 		for (const el of Object.keys(SUB_ELEMENT)) {
 			if (SUB_ELEMENT[Number(el)][router.pathname]) {
-				
 				setSelectedMain(() => Number(el))
 				const curRoute = SUB_ELEMENT[Number(el)][router.pathname]
 
@@ -82,9 +79,7 @@ function SideBar({ children }: SideBarProps) {
 				}
 				return
 			} else {
-
 				if (Object.keys(SUB_ELEMENT).length - 1 === Number(el) && selectedMain == -1 && selectedSub == -1) {
-					
 					setSelectedMain(() => -2)
 					setSelectedSub(() => -2)
 				} else if (!SUB_ELEMENT[Number(el)][router.pathname]) {
@@ -92,11 +87,8 @@ function SideBar({ children }: SideBarProps) {
 					setSelectedSub(() => -2)
 				}
 			}
-			
-				
-			
 		}
-		
+
 		// return () => {
 		// 	if (selectedMain == -1 && selectedSub == -1) {
 		// 		setSelectedMain(() => -2)
@@ -104,10 +96,7 @@ function SideBar({ children }: SideBarProps) {
 		// 		alert('dfggrfw')
 		// 	}
 		// }
-
 	}, [router.pathname])
-
-
 
 	const selectMainHandler = (value: number) => {
 		// setSelectedMain(() => value)
@@ -120,7 +109,7 @@ function SideBar({ children }: SideBarProps) {
 		router.push(Object.keys(SUB_ELEMENT[selectedMain])[value])
 	}
 
-	const MAIN_LOGO = <img css={logoCSS} src={"/assets/icon_desktop.png"} />
+	const MAIN_LOGO = <img css={logoCSS} src={"/assets/icon_desktop.png"} alt="교사회원 메인 아이콘" />
 
 	const MAIN_ELEMENT: { [prop: number]: { name: string; label: string; content: any } } = {
 		0: { name: "class", label: "우리 반", content: MAIN_CLASS },
@@ -165,7 +154,12 @@ function SideBar({ children }: SideBarProps) {
 				menuIndex: 1,
 			},
 			"/teacher/gov/job": { name: "set_job", label: "직업 관리", content: SUB_GOVERNMENT_JOB, menuIndex: 2 },
-			"/teacher/gov/economy": { name: "view_economy", label: "경제 현황", content: SUB_GOVERNMENT_ECONOMY, menuIndex: 3 },
+			"/teacher/gov/economy": {
+				name: "view_economy",
+				label: "경제 현황",
+				content: SUB_GOVERNMENT_ECONOMY,
+				menuIndex: 3,
+			},
 		},
 		2: {
 			"/teacher/finance/deposit": { name: "set_deposit", label: "예금", content: SUB_FINANCE_DEPOSIT, menuIndex: 0 },
@@ -232,7 +226,6 @@ function SideBar({ children }: SideBarProps) {
 
 	return (
 		<div css={layoutWrapperCSS}>
-			
 			{selectedMain >= 0 && selectedSub >= 0 ? sideBarRender : selectedMain === -2 && selectedSub === -2 && children}
 		</div>
 	)

--- a/ico/src/components/teacher/layout/SideBar/SideBarLeft.tsx
+++ b/ico/src/components/teacher/layout/SideBar/SideBarLeft.tsx
@@ -1,12 +1,12 @@
-import React from 'react'
+import React from "react"
 import { css } from "@emotion/react"
 import { MAIN_SETTING, MAIN_SIGNOUT } from "./SideBarIcons"
 import { removeCookie } from "@/api/cookie"
 import { useRouter } from "next/router"
 import useGetTokenStatus from "@/hooks/useGetTokenStatus"
-import useCompHandler from '@/hooks/useCompHandler'
-import Modal from '@/components/common/Modal/Modal'
-import Account from '../../Account/Account'
+import useCompHandler from "@/hooks/useCompHandler"
+import Modal from "@/components/common/Modal/Modal"
+import Account from "../../Account/Account"
 
 type SideBarLeftProps = {
 	element: { [prop: number]: { name: string; label: string; content: any } }
@@ -44,7 +44,7 @@ function SideBarLeft({ element, logo, selectHandler, selected }: SideBarLeftProp
 
 	return (
 		<React.Fragment>
-			<Modal compState={compState} closeComp={closeComp} transition={'scale'} content={<Account/>}/>
+			<Modal compState={compState} closeComp={closeComp} transition={"scale"} content={<Account />} />
 			<div css={sideBarLeftWrapperCSS}>
 				<div css={topWrapperCSS}>
 					<div css={logoWrapperCSS}>{logo}</div>
@@ -63,7 +63,7 @@ function SideBarLeft({ element, logo, selectHandler, selected }: SideBarLeftProp
 						<div css={elementContentCSS}>{MAIN_SETTING}</div>
 					</div>
 					<div css={bottomLineCSS} />
-					<img css={userImgCSS} src={"/assets/account.png"} alt="" onClick={openComp} />
+					<img css={userImgCSS} src={"/assets/account.png"} alt="교사회원 계정확인 아이콘" onClick={openComp} />
 				</div>
 			</div>
 		</React.Fragment>

--- a/ico/src/pages/_app.tsx
+++ b/ico/src/pages/_app.tsx
@@ -8,11 +8,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import StackNotification from "@/components/common/StackNotification/StackNotification"
 
-
 export default function App({ Component, pageProps }: AppProps) {
 	const queryClient = new QueryClient()
-
-	
 
 	return (
 		<CookiesProvider>

--- a/ico/src/pages/_document.tsx
+++ b/ico/src/pages/_document.tsx
@@ -2,9 +2,13 @@ import { Html, Head, Main, NextScript } from "next/document"
 
 export default function Document() {
 	return (
-		<Html lang="en">
+		<Html lang="ko">
 			<Head>
 				<link rel="shortcut icon" href="/favicon.ico" />
+				<title>학급 경제 교육 플랫폼 | 아이코</title>
+				<meta name="description" content="초등학생 학급 경제 교육 플랫폼 웹/앱 서비스"></meta>
+				<meta name="keywords" content="초등학생, 경제교육"></meta>
+				<meta name="author" content="ICO"></meta>
 			</Head>
 			<link rel="manifest" href="/manifest.json" />
 			<meta name="theme-color" content="#fffae2" />
@@ -30,9 +34,7 @@ export default function Document() {
 			<meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
 			<body>
 				<link href="https://webfontworld.github.io/sunn/SUIT.css" rel="stylesheet"></link>
-				{/* modal이 렌더링 될 위치 */}
 				<div id="portal" />
-
 				<Main />
 				<NextScript />
 			</body>

--- a/ico/src/styles/globals.css
+++ b/ico/src/styles/globals.css
@@ -11,6 +11,7 @@
 	--teacher-warning-color: #d94a4a;
 	--teacher-gray-color: #6e6f71;
 	--teacher-gray2-color: #d9d9d9;
+	--teacher-gray3-color: #434242;
 	--teacher-blue-color: #4b7cc6;
 	--teacher-coupon-color: #ef5b5b;
 
@@ -37,8 +38,6 @@
 	@media (max-width: 768px) {
 		--student-full-width: 100vw;
 	}
-
-
 
 	@media (min-width: 769px) {
 		--student-full-width: calc(100vw - var(--student-side-bar-width));


### PR DESCRIPTION
## 주요 구현 사항
#### 1. 버튼의 색상 대비 변경
* 사용자가 저대비 텍스트를 읽는 데 어려움을 겪거나 전혀 읽지 못하는 경우를 고려하여 색상 변경
* [이 사이트](https://dequeuniversity.com/rules/axe/4.6/color-contrast)의 색상 대비 분석 도구를 통해 편하게 확인하고 적용할 수 있습니다!
#### 2. 알맞지 않은 제목 태그 사용 수정
* 학생 정보 표현에 필요한 태그를 `font-size`에 맞게 제목 태그(`<h5>`)를 사용했으나, 실제 제목이 아닌 텍스트에는 제목 마크업을 사용하지 않아야 된다는 권장 사항에 따라 수정
#### 3. `input` 태그에 `label` 추가
* `input` 태그 사용 시 `label` 태그를 사용하면 스크린 리더 등의 보조 기술을 사용하는 사용자도 입력 필드의 레이블을 이해할 수 있고, 사용자 경험을 향상 시킨다는 점에서 `input` 태그 사용 시 `label` 태그 사용 권장
#### 4. title 및 meta 태그 추가
* SEO를 위해 _document.tsx의 `<Head></Head>` 안에 `<title>`태그와 `<meta>`태그 추가
#### 5. 이미지 태그에 alt 속성 추가
#### 6. 사용하지 않는 코드 제거 및 불필요한 공백 제거

## 의견 공유
* 교사 페이지의 사이드바에 적용된 아이콘과 글씨들의 색상 대비도 Lighthouse의 경고를 받은 만큼 변경할 수 있으면 좋을 것 같습니다 🙂
* 일반적으로 `<meta>` 태그는 `<head>` 요소 내에 위치하는데, 현재는 `<head>` 요소 내에 위치하지 않은 `<meta>` 태그들이 많은 것 같습니다! 이유가 있는지 피드백 적어주시면 감사하겠읍니다 🙂