### PR TITLE
fix : 직업 등록 시 학생 이름에 NULL이 들어가는 것 방지

### DIFF
--- a/Back-end/api-module/src/main/java/com/ico/api/service/certification/CertificationServiceImpl.java
+++ b/Back-end/api-module/src/main/java/com/ico/api/service/certification/CertificationServiceImpl.java
@@ -41,6 +41,7 @@ public class CertificationServiceImpl implements CertificationService{
     private final TeacherRepository teacherRepository;
     private final S3UploadService s3;
     private final CoolSMSService smsService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     @Transactional
@@ -67,6 +68,8 @@ public class CertificationServiceImpl implements CertificationService{
 
         // Certification 삭제
         certificationRepository.delete(certification);
+
+        jwtTokenProvider.updateTokenCookie(request);
     }
 
     @Override

--- a/Back-end/api-module/src/main/java/com/ico/api/service/job/JobServiceImpl.java
+++ b/Back-end/api-module/src/main/java/com/ico/api/service/job/JobServiceImpl.java
@@ -183,6 +183,7 @@ public class JobServiceImpl implements JobService{
                 .creditRating(dto.getCreditRating() != null ? dto.getCreditRating().byteValue() : (byte) 10)
                 .total(dto.getTotal().byteValue())
                 .color(dto.getColor())
+                .studentNames("")
                 .build();
         if (!dto.getEmpowered().isEmpty()) {
             addJobPower(studentJob, dto.getEmpowered());

--- a/Back-end/api-module/src/main/java/com/ico/api/service/nation/NationServiceImpl.java
+++ b/Back-end/api-module/src/main/java/com/ico/api/service/nation/NationServiceImpl.java
@@ -104,7 +104,7 @@ public class NationServiceImpl implements NationService {
         Teacher teacher = teacherRepository.findById(teacherId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         // 교사 인증 여부
-        if (teacher.getStatus().equals(Status.APPROVED)) {
+        if (!teacher.getStatus().equals(Status.APPROVED)) {
             throw new CustomException(ErrorCode.NOT_FOUND_TEACHER_CERTIFICATION);
         }
         // 교사가 만든 나라의 여부


### PR DESCRIPTION
지금 NULL이 들어가서 학생이 직업을 가질 때 StudentNames에 NULL학생이름, 이런식으로 뜸